### PR TITLE
fix:reverse is_day to be correct

### DIFF
--- a/cypress/component/components/current.weather.card.cy.js
+++ b/cypress/component/components/current.weather.card.cy.js
@@ -1,6 +1,7 @@
 import CurrentWeatherCard from "../../../src/components/current.weather.card";
 import CurrentWeatherCardObject from "../../page_objects/components/current.weather.card.object";
 import { getLocationName } from "../../../src/services/open_meteo_api/utils";
+import { IsDay } from "../../../src/services/api";
 
 describe(CurrentWeatherCard.name, function () {
     beforeEach(function () {
@@ -26,31 +27,33 @@ describe(CurrentWeatherCard.name, function () {
                 cwco.temperature.should("have.text", "51 °F");
                 cwco.temperatureRange.should("have.text", "48 °F / 55 °F");
                 cwco.PrecipitationChanceObject((pco) => pco._assertValue("0.1 inch"));
-                cwco.WeatherIconObject((wio) => {
-                    wio.__assertTooltipText("Overcast");
-                    wio.__assertIcon("wi wi-day-sunny-overcast");
-                });
+                cwco.WeatherIconObject((wio) => wio.__assertTooltipText("Overcast"));
                 cwco.time.should("have.text", "Last updated: Nov 14, 2023, 9:30 PM");
             });
         });
     });
 
-    specify("displays the nighttime variant for the weather icon at night", function () {
-        cy.get(`@locationData`).then((locationData) => {
-            cy.get(`@weatherData`).then((weatherData) => {
-                weatherData.current_weather.mapped.is_day = 1;
-                cy.mount(
-                    <CurrentWeatherCard
-                        locationName={getLocationName(locationData)}
-                        currentWeatherData={weatherData.current_weather}
-                    />
-                );
+    [
+        { key: IsDay.DAY, expectedClassName: "wi wi-day-sunny-overcast" },
+        { key: IsDay.NIGHT, expectedClassName: "wi wi-night-alt-cloudy" },
+    ].forEach(({ key, expectedClassName }) => {
+        specify(`displays the variant for the weather icon at ${IsDay[key]}`, function () {
+            cy.get(`@locationData`).then((locationData) => {
+                cy.get(`@weatherData`).then((weatherData) => {
+                    weatherData.current_weather.mapped.is_day = key;
+                    cy.mount(
+                        <CurrentWeatherCard
+                            locationName={getLocationName(locationData)}
+                            currentWeatherData={weatherData.current_weather}
+                        />
+                    );
 
-                const cwco = new CurrentWeatherCardObject();
+                    const cwco = new CurrentWeatherCardObject();
 
-                cwco.WeatherIconObject((wio) => {
-                    wio.__assertTooltipText("Overcast");
-                    wio.__assertIcon("wi wi-night-alt-cloudy");
+                    cwco.WeatherIconObject((wio) => {
+                        wio.__assertTooltipText("Overcast");
+                        wio.__assertIcon(expectedClassName);
+                    });
                 });
             });
         });

--- a/cypress/component/components/weather.icon.cy.js
+++ b/cypress/component/components/weather.icon.cy.js
@@ -172,7 +172,7 @@ describe(WeatherIcon.name, function () {
             it("has a nighttime icon variant", function () {
                 const wio = new WeatherIconObject();
 
-                cy.mount(<WeatherIcon weatherCode={weatherCode} isDay={false} />);
+                cy.mount(<WeatherIcon weatherCode={weatherCode} isDay={0} />);
 
                 wio.__assertIcon(`wi ${classNameNightVariant}`);
             });
@@ -184,9 +184,7 @@ describe(WeatherIcon.name, function () {
                 cy.mount(<WeatherIcon weatherCode={weatherCode} modifiers={modifiers} />);
                 wio.__assertIcon(`wi ${className} wi-flip-horizontal wi-rotate-90 wi-fw`);
 
-                cy.mount(
-                    <WeatherIcon weatherCode={weatherCode} modifiers={modifiers} isDay={false} />
-                );
+                cy.mount(<WeatherIcon weatherCode={weatherCode} modifiers={modifiers} isDay={0} />);
                 wio.__assertIcon(
                     `wi ${classNameNightVariant} wi-flip-horizontal wi-rotate-90 wi-fw`
                 );

--- a/src/components/weather.accordion.tsx
+++ b/src/components/weather.accordion.tsx
@@ -17,7 +17,7 @@ import PrecipitationChance from "./precipitation.chance";
 import WeatherIcon from "./weather.icon";
 import { NOT_AVAILABLE_TEXT } from "../constants";
 import { isMobile, shadows, weatherCodeToText } from "./utils";
-import { DailyWeatherDataMappings, HourlyWeatherDataMappings } from "../services/api";
+import { DailyWeatherDataMappings, HourlyWeatherDataMappings, IsDay } from "../services/api";
 import { isEqual } from "lodash";
 import { DateTime, Zone } from "luxon";
 import { WeatherCode } from "../services/open_meteo_api/forecast_api";
@@ -71,8 +71,10 @@ const WeatherAccordionSummary = ({
     const timeString = getTimeStringForSummary(type, mappedWeatherData.time, timezone || "local");
     //@ts-ignore: TS2339 -- We don't need to enforce this. mappedWeatherData can be hourly or daily.
     const temperature = mappedWeatherData.temperature || mappedWeatherData.temperature_range;
+
+    //Default to daytime variant
     //@ts-ignore: TS2339 -- We don't need to enforce this.
-    const isDay = mappedWeatherData.is_day ?? true;
+    const isDay = mappedWeatherData.is_day ?? IsDay.DAY;
 
     return (
         <AccordionSummary

--- a/src/components/weather.icon.tsx
+++ b/src/components/weather.icon.tsx
@@ -22,24 +22,22 @@ interface WeatherIconProps {
 export const weatherCodeToClassName = (
     weatherCode: number | WeatherCode,
     modifiers: string[] = [],
-    isDay: IsDay = true
+    isDay: IsDay = IsDay.DAY
 ): string => {
-    if (isEqual(typeof isDay, "number")) {
-        isDay = isEqual(isDay, 0);
-    }
     weatherCode = Number(weatherCode);
+    const setAsDay = isEqual(isDay, 1);
     const getBaseClass = (): string => {
         switch (true) {
             case includes([WeatherCode.MAINLY_CLEAR, WeatherCode.CLEAR_SKY], weatherCode):
-                return isDay ? "wi-day-sunny" : "wi-night-clear";
+                return setAsDay ? "wi-day-sunny" : "wi-night-clear";
             case includes([WeatherCode.PARTLY_CLOUDY], weatherCode):
-                return isDay ? "wi-day-cloudy" : "wi-night-alt-partly-cloudy";
+                return setAsDay ? "wi-day-cloudy" : "wi-night-alt-partly-cloudy";
             case includes([WeatherCode.OVERCAST], weatherCode):
                 //There's no overcast at night, so default to a different variant
-                return isDay ? "wi-day-sunny-overcast" : "wi-night-alt-cloudy";
+                return setAsDay ? "wi-day-sunny-overcast" : "wi-night-alt-cloudy";
             case includes([WeatherCode.FOG, WeatherCode.DEPOSITING_RIME_FOG], weatherCode):
                 //No "night-alt" variant
-                return isDay ? "wi-day-fog" : "wi-night-fog";
+                return setAsDay ? "wi-day-fog" : "wi-night-fog";
             case includes(
                 [
                     WeatherCode.THUNDERSTORM,
@@ -48,7 +46,7 @@ export const weatherCodeToClassName = (
                 ],
                 weatherCode
             ):
-                return isDay ? "wi-day-thunderstorm" : "wi-night-alt-thunderstorm";
+                return setAsDay ? "wi-day-thunderstorm" : "wi-night-alt-thunderstorm";
             case includes(
                 [
                     WeatherCode.SLIGHT_RAIN,
@@ -59,7 +57,7 @@ export const weatherCodeToClassName = (
                 ],
                 weatherCode
             ):
-                return isDay ? "wi-day-rain" : "wi-night-alt-rain";
+                return setAsDay ? "wi-day-rain" : "wi-night-alt-rain";
             case includes(
                 [
                     WeatherCode.SLIGHT_RAIN_SHOWERS,
@@ -68,7 +66,7 @@ export const weatherCodeToClassName = (
                 ],
                 weatherCode
             ):
-                return isDay ? "wi-day-showers" : "wi-night-alt-showers";
+                return setAsDay ? "wi-day-showers" : "wi-night-alt-showers";
             case includes(
                 [
                     WeatherCode.LIGHT_DRIZZLE,
@@ -79,7 +77,7 @@ export const weatherCodeToClassName = (
                 ],
                 weatherCode
             ):
-                return isDay ? "wi-day-sprinkle" : "wi-night-alt-sprinkle";
+                return setAsDay ? "wi-day-sprinkle" : "wi-night-alt-sprinkle";
             case includes(
                 [
                     WeatherCode.SNOW_GRAINS,
@@ -89,12 +87,12 @@ export const weatherCodeToClassName = (
                 ],
                 weatherCode
             ):
-                return isDay ? "wi-day-snow" : "wi-night-alt-snow";
+                return setAsDay ? "wi-day-snow" : "wi-night-alt-snow";
             case includes(
                 [WeatherCode.LIGHT_SNOW_SHOWERS, WeatherCode.HEAVY_SNOW_SHOWERS],
                 weatherCode
             ):
-                return isDay ? "wi-day-sleet" : "wi-night-alt-sleet";
+                return setAsDay ? "wi-day-sleet" : "wi-night-alt-sleet";
             default:
                 //Default an icon for "Not available"
                 return "wi-na";

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -11,7 +11,10 @@ import {
 import { DateTime } from "luxon";
 import { gte, isEqual, isNil } from "lodash";
 
-export type IsDay = boolean | 0 | 1;
+export enum IsDay {
+    NIGHT = 0,
+    DAY = 1,
+}
 
 type ISOString = string;
 
@@ -361,7 +364,6 @@ export default class SimpleWeatherAPI {
         };
     }
 
-    //TODO: allow for units of measurement and temperature units (m vs inch; C vs F)
     //TODO: pass in timezone from system
     static async getWeather(
         coordinates: Coordinates,


### PR DESCRIPTION
# What
Fix for an issue from #37 
The `isDay` was not correct. `0` is night, and `1` is day, but I had it backwards originally. It's now fixed.